### PR TITLE
Fix highlight.js CDN script to avoid require error

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ require __DIR__ . '/../src/bootstrap.php';
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" defer></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/build/highlight.min.js" defer></script>
     <script>
         window.PROMPT_VERSION = '<?php echo Questionnaire\Support\Prompt::VERSION; ?>';
         window.OPENAI_ENABLED = <?php echo Questionnaire\Support\Env::openAiEnabled() ? 'true' : 'false'; ?>;


### PR DESCRIPTION
## Summary
- replace the Highlight.js CDN script with the browser-ready build to prevent `require` from being used in the browser context

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dced6aec50833080d7a54b7b83fc0d