### PR TITLE
Replace highlight.js CDN with lightweight local highlighter

### DIFF
--- a/public/assets/light-highlight.js
+++ b/public/assets/light-highlight.js
@@ -1,0 +1,99 @@
+(function () {
+  function escapeHtml(value) {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function createStash() {
+    const entries = [];
+    return {
+      push(match, className) {
+        const key = `__HLJS_TOKEN_${entries.length}__`;
+        entries.push({ key, html: `<span class="hljs-${className}">${escapeHtml(match)}</span>` });
+        return key;
+      },
+      restore(content) {
+        return entries.reduce((acc, entry) => acc.split(entry.key).join(entry.html), content);
+      }
+    };
+  }
+
+  function highlightJson(source) {
+    const stash = createStash();
+    let working = source;
+
+    const propertyRegex = /"(?:\\.|[^"\\])*"(?=\s*:)/g;
+    const stringRegex = /"(?:\\.|[^"\\])*"/g;
+    const numberRegex = /-?\b\d+(?:\.\d+)?(?:e[+\-]?\d+)?\b/gi;
+    const booleanRegex = /\b(?:true|false)\b/gi;
+    const nullRegex = /\bnull\b/gi;
+
+    working = working.replace(propertyRegex, (match) => stash.push(match, 'attr'));
+    working = working.replace(stringRegex, (match) => stash.push(match, 'string'));
+    working = working.replace(booleanRegex, (match) => stash.push(match, 'boolean'));
+    working = working.replace(nullRegex, (match) => stash.push(match, 'null'));
+    working = working.replace(numberRegex, (match) => stash.push(match, 'number'));
+
+    const escaped = escapeHtml(working);
+    return stash.restore(escaped);
+  }
+
+  function highlightGeneric(source) {
+    const stash = createStash();
+    let working = source;
+
+    const commentRegex = /(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)/g;
+    const stringRegex = /`(?:\\.|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
+    const numberRegex = /\b\d+(?:\.\d+)?\b/g;
+    const booleanRegex = /\b(?:true|false)\b/gi;
+
+    working = working.replace(commentRegex, (match) => stash.push(match, 'comment'));
+    working = working.replace(stringRegex, (match) => stash.push(match, 'string'));
+    working = working.replace(booleanRegex, (match) => stash.push(match, 'boolean'));
+    working = working.replace(numberRegex, (match) => stash.push(match, 'number'));
+
+    let escaped = escapeHtml(working);
+
+    const keywordRegex = /\b(abstract|as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/g;
+    const constantRegex = /\b[A-Z_][A-Z0-9_]*\b/g;
+
+    escaped = escaped.replace(keywordRegex, (match) => `<span class="hljs-keyword">${match}</span>`);
+    escaped = escaped.replace(constantRegex, (match) => `<span class="hljs-constant">${match}</span>`);
+
+    return stash.restore(escaped);
+  }
+
+  function detectLanguage(element, content) {
+    const declared = (element.getAttribute('data-language') || element.getAttribute('data-lang') || element.className || '').toLowerCase();
+    if (declared.includes('json')) {
+      return 'json';
+    }
+    if (declared.includes('javascript') || declared.includes('js') || declared.includes('ts')) {
+      return 'generic';
+    }
+    const trimmed = content.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      return 'json';
+    }
+    return 'generic';
+  }
+
+  function highlightElement(element) {
+    const original = element.textContent || '';
+    if (!original.trim()) {
+      return;
+    }
+    const language = detectLanguage(element, original);
+    const html = language === 'json' ? highlightJson(original) : highlightGeneric(original);
+    element.innerHTML = html;
+    element.classList.add('hljs');
+  }
+
+  window.hljs = {
+    highlightElement
+  };
+})();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -274,3 +274,52 @@ body {
         flex-direction: column;
     }
 }
+
+pre code {
+  display: block;
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: #f6f8fa;
+  border-radius: 8px;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.hljs {
+  color: #24292f;
+}
+
+.hljs-comment {
+  color: #6a737d;
+  font-style: italic;
+}
+
+.hljs-keyword {
+  color: #d73a49;
+  font-weight: 600;
+}
+
+.hljs-string {
+  color: #032f62;
+}
+
+.hljs-number {
+  color: #005cc5;
+}
+
+.hljs-boolean,
+.hljs-constant {
+  color: #005cc5;
+  font-weight: 600;
+}
+
+.hljs-null {
+  color: #6a737d;
+  font-weight: 600;
+}
+
+.hljs-attr {
+  color: #005cc5;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -10,8 +10,7 @@ require __DIR__ . '/../src/bootstrap.php';
     <link rel="stylesheet" href="assets/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" defer></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js" defer></script>
+    <script src="assets/light-highlight.js" defer></script>
     <script>
         window.PROMPT_VERSION = '<?php echo Questionnaire\Support\Prompt::VERSION; ?>';
         window.OPENAI_ENABLED = <?php echo Questionnaire\Support\Env::openAiEnabled() ? 'true' : 'false'; ?>;


### PR DESCRIPTION
## Summary
- replace the external highlight.js CDN with a bundled lightweight highlighter to avoid ORB blocking errors
- add styling for highlighted code blocks to mimic the previous theme

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dced6aec50833080d7a54b7b83fc0d