### PR TITLE
Handle streamed delta chunks when parsing responses

### DIFF
--- a/src/Support/ResponseFormatter.php
+++ b/src/Support/ResponseFormatter.php
@@ -17,7 +17,9 @@ final class ResponseFormatter
         $buffer = '';
         foreach ($chunks as $chunk) {
             foreach ($chunk['content'] as $content) {
-                if (($content['type'] ?? '') === 'output_text') {
+                $type = $content['type'] ?? '';
+
+                if ($type === 'output_text' || $type === 'output_text_delta') {
                     $buffer .= $content['text'] ?? '';
                 }
             }


### PR DESCRIPTION
## Summary
- include `output_text_delta` chunks when rebuilding the assistant markdown from the streamed OpenAI response
- ensure the initial streamed reply is no longer empty by concatenating delta text segments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd427e03988330a2f4ddb255f1e796